### PR TITLE
Added Eyed3 Library for automating metadata information of each mp3

### DIFF
--- a/hypeme.py
+++ b/hypeme.py
@@ -27,6 +27,7 @@ from bs4 import BeautifulSoup
 import json
 import string
 import os
+import eyed3
 
 ##############AREA_TO_SCRAPE################
 # This is the general area that you'd 
@@ -146,6 +147,8 @@ class HypeScraper:
           mp3_song_file = open(filename, "wb")
           mp3_song_file.write(download_response.read() )
           mp3_song_file.close()
+
+          edit_metadata(filename, artist, title)
       except urllib2.HTTPError, e:
             print 'HTTPError = ' + str(e.code) + " trying hypem download url."
       except urllib2.URLError, e:
@@ -153,7 +156,12 @@ class HypeScraper:
       except Exception, e:
             print 'generic exception: ' + str(e)
       
-  
+def edit_metadata(filename, artist, title):
+  song = eyed3.load(filename)
+  song.initTag()
+  song.tag.artist = unicode(artist, "utf-8")
+  song.tag.title = unicode(title, "utf-8")
+  song.tag.save()
      
 
 def main():


### PR DESCRIPTION
I noticed that the filenames were being formatted but there was no
metadata being put into them. When I tried asking my music app for
album covers, it couldn’t provide any because the metadata for all the songs was empty.

I’m using the Eyed3 Python library which allows tag editing for mp3s. All you need to do is install the library similar to the way you would install BeautifulSoup:

```
pip install eyeD3
```

The awesome thing about having artist and title tags inside the mp3 is that if you pull the songs into VLC, VLC will automatically download the album covers for every song!

![image](https://cloud.githubusercontent.com/assets/5403938/8609618/926b7d02-265c-11e5-8fde-1080ee1c2691.png)
